### PR TITLE
use lbot in lbot cfg

### DIFF
--- a/Osiris/GUI.cpp
+++ b/Osiris/GUI.cpp
@@ -295,7 +295,7 @@ void GUI::renderLegitbotWindow() noexcept
     ImGui::SliderFloat("Fov", &config->legitbot[currentWeapon].fov, 0.0f, 255.0f, "%.2f", ImGuiSliderFlags_Logarithmic);
     ImGui::SliderFloat("Smooth", &config->legitbot[currentWeapon].smooth, 1.0f, 100.0f, "%.2f");
     ImGui::SliderInt("Reaction time", &config->legitbot[currentWeapon].reactionTime, 0, 300, "%d");
-    ImGui::SliderInt("Min damage", &config->ragebot[currentWeapon].minDamage, 0, 101, "%d");
+    ImGui::SliderInt("Min damage", &config->legitbot[currentWeapon].minDamage, 0, 101, "%d");
     config->legitbot[currentWeapon].minDamage = std::clamp(config->legitbot[currentWeapon].minDamage, 0, 250);
     ImGui::Checkbox("Killshot", &config->legitbot[currentWeapon].killshot);
     ImGui::Checkbox("Between shots", &config->legitbot[currentWeapon].betweenShots);


### PR DESCRIPTION
Currently `cfg[weaponIndex].minDamage` in [Legitbot.cpp#L145](https://github.com/notgoodusename/OsirisAndExtra/blob/main/Osiris/Hacks/Legitbot.cpp#L145) with `const auto& cfg = config->legitbot;` in [Legitbot.cpp#L33](https://github.com/notgoodusename/OsirisAndExtra/blob/main/Osiris/Hacks/Legitbot.cpp#L33) reads the correct value however [GUI.cpp#L298](https://github.com/notgoodusename/OsirisAndExtra/blob/main/Osiris/GUI.cpp#L298) reads/writes to the ragebot field thus a user can never change legitbot min damage via the GUI.