### PR TITLE
min damage override

### DIFF
--- a/Osiris/Config.cpp
+++ b/Osiris/Config.cpp
@@ -272,6 +272,7 @@ static void from_json(const json& j, Config::Ragebot& r)
     read(j, "Hitchance", r.hitChance);
     read(j, "Multipoint", r.multiPoint);
     read(j, "Min damage", r.minDamage);
+    read(j, "Min damage override", r.minDamageOverride);
 }
 
 static void from_json(const json& j, Config::Triggerbot& t)
@@ -695,6 +696,7 @@ void Config::load(const char8_t* name, bool incremental) noexcept
 
     read(j, "Ragebot", ragebot);
     read(j, "Ragebot Key", ragebotKey);
+    read(j, "Min Damage Override Key", minDamageOverrideKey);
 
     read(j, "Triggerbot", triggerbot);
     read(j, "Triggerbot Key", triggerbotKey);
@@ -905,6 +907,7 @@ static void to_json(json& j, const Config::Ragebot& o, const Config::Ragebot& du
     WRITE("Hitchance", hitChance);
     WRITE("Multipoint", multiPoint);
     WRITE("Min damage", minDamage);
+    WRITE("Min damage override", minDamageOverride);
 }
 
 static void to_json(json& j, const Config::Triggerbot& o, const Config::Triggerbot& dummy = {})
@@ -1356,6 +1359,7 @@ void Config::save(size_t id) const noexcept
 
         j["Ragebot"] = ragebot;
         to_json(j["Ragebot Key"], ragebotKey, KeyBind::NONE);
+        to_json(j["Min Damage Override Key"], minDamageOverrideKey, KeyBind::NONE);
 
         j["Triggerbot"] = triggerbot;
         to_json(j["Triggerbot Key"], triggerbotKey, KeyBind::NONE);

--- a/Osiris/Config.h
+++ b/Osiris/Config.h
@@ -51,9 +51,11 @@ public:
         int hitChance{ 50 };
         int multiPoint{ 0 };
         int minDamage{ 1 };
+        int minDamageOverride{ 1 };
     };
     std::array<Ragebot, 40> ragebot;
     KeyBind ragebotKey{ std::string("ragebot") };
+    KeyBind minDamageOverrideKey{ std::string("min damage override") };
 
     struct Fakelag {
         bool enabled = false;

--- a/Osiris/GUI.cpp
+++ b/Osiris/GUI.cpp
@@ -319,7 +319,8 @@ void GUI::renderRagebotWindow() noexcept
     ImGui::hotkey2("Key", config->ragebotKey);
     ImGui::PopID();
     ImGui::SameLine();
-    ImGui::PushID(2);
+    ImGui::PushID("Min Damage Override Key");
+    ImGui::hotkey2("Min Damage Override Key", config->minDamageOverrideKey);
     ImGui::PopID();
     ImGui::Separator();
     static int currentCategory{ 0 };
@@ -472,6 +473,8 @@ void GUI::renderRagebotWindow() noexcept
     ImGui::SliderInt("Multipoint", &config->ragebot[currentWeapon].multiPoint, 0, 100, "%d");
     ImGui::SliderInt("Min damage", &config->ragebot[currentWeapon].minDamage, 0, 101, "%d");
     config->ragebot[currentWeapon].minDamage = std::clamp(config->ragebot[currentWeapon].minDamage, 0, 250);
+    ImGui::SliderInt("Min damage override", &config->ragebot[currentWeapon].minDamageOverride, 0, 101, "%d");
+    config->ragebot[currentWeapon].minDamageOverride = std::clamp(config->ragebot[currentWeapon].minDamageOverride, 0, 250);
     ImGui::Columns(1);
 }
 

--- a/Osiris/Hacks/Misc.cpp
+++ b/Osiris/Hacks/Misc.cpp
@@ -783,6 +783,7 @@ void Misc::updateClanTag(bool tagChanged) noexcept
 const bool anyActiveKeybinds() noexcept
 {
     const bool rageBot = config->ragebotKey.canShowKeybind();
+    const bool minDamageOverride = config->minDamageOverrideKey.canShowKeybind();
     const bool fakeAngle = config->fakeAngle.enabled && config->fakeAngle.invert.canShowKeybind();
     const bool legitAntiAim = config->legitAntiAim.enabled && config->legitAntiAim.invert.canShowKeybind();
     const bool legitBot = config->legitbotKey.canShowKeybind();
@@ -804,7 +805,7 @@ const bool anyActiveKeybinds() noexcept
     const bool autoPeek = config->misc.autoPeek.enabled && config->misc.autoPeekKey.canShowKeybind();
     const bool prepareRevolver = config->misc.prepareRevolver && config->misc.prepareRevolverKey.canShowKeybind();
 
-    return rageBot || fakeAngle || legitAntiAim || legitBot || triggerBot || chams || glow || esp
+    return rageBot || minDamageOverride || fakeAngle || legitAntiAim || legitBot || triggerBot || chams || glow || esp
         || zoom || thirdperson || freeCam || blockbot || edgejump || edgebug || jumpBug || slowwalk || fakeduck || autoPeek || prepareRevolver;
 }
 
@@ -836,6 +837,7 @@ void Misc::showKeybinds() noexcept
     ImGui::PopStyleVar();
 
     config->ragebotKey.showKeybind();
+    config->minDamageOverrideKey.showKeybind();
     if (config->fakeAngle.enabled)
         config->fakeAngle.invert.showKeybind();
     if (config->legitAntiAim.enabled)

--- a/Osiris/Hacks/Ragebot.cpp
+++ b/Osiris/Hacks/Ragebot.cpp
@@ -23,6 +23,7 @@ static bool keyPressed = false;
 void Ragebot::updateInput() noexcept
 {
     config->ragebotKey.handleToggle();
+    config->minDamageOverrideKey.handleToggle();
 }
 
 void Ragebot::run(UserCmd* cmd) noexcept
@@ -142,7 +143,7 @@ void Ragebot::run(UserCmd* cmd) noexcept
     {
         const auto entity{ interfaces->entityList->getEntity(target.id) };
         const auto player = Animations::getPlayer(target.id);
-        const int minDamage = std::clamp(std::clamp(cfg[weaponIndex].minDamage, 0, target.health), 0, activeWeapon->getWeaponData()->damage);
+        const int minDamage = std::clamp(std::clamp(config->minDamageOverrideKey.isActive() ? cfg[weaponIndex].minDamageOverride : cfg[weaponIndex].minDamage, 0, target.health), 0, activeWeapon->getWeaponData()->damage);
         damageDiff = FLT_MAX;
 
         auto backupBoneCache = entity->getBoneCache().memory;


### PR DESCRIPTION
Since the code is somewhat of a mess and I couldn't figure out the exact naming scheme I just went with this. Maybe you want to change the name and reposition the keybind.

I opted for one override key overall and individual min dmgs to override on a weapon basis.

Also I think for things like this and slowwalk it would make sense if the keybind window can view the current values as well. Could be implemented by allowing `KeyBind::showKeybind()` to take an optional value which then gets added to the end of the string.