### PR TITLE
implement manual aa

### DIFF
--- a/Osiris/Config.cpp
+++ b/Osiris/Config.cpp
@@ -300,7 +300,11 @@ static void from_json(const json& j, Config::RageAntiAimConfig& a)
 {
     read(j, "Enabled", a.enabled);
     read(j, "Pitch", a.pitch);
-    read(j, "Yaw base", a.yawBase);
+    read(j, "Yaw base", reinterpret_cast<int&>(a.yawBase));
+    read(j, "Manual forward Key", a.manualForward);
+    read(j, "Manual backward Key", a.manualBackward);
+    read(j, "Manual right Key", a.manualRight);
+    read(j, "Manual left Key", a.manualLeft);
     read(j, "Yaw add", a.yawAdd);
     read(j, "Jitter Range", a.jitterRange);
     read(j, "Spin base", a.spinBase);
@@ -637,6 +641,7 @@ static void from_json(const json& j, Config::Misc& m)
     read(j, "Fast Stop", m.fastStop);
     read<value_t::object>(j, "Bomb timer", m.bombTimer);
     read<value_t::object>(j, "Hurt indicator", m.hurtIndicator);
+    read<value_t::object>(j, "Yaw indicator", m.yawIndicator);
     read(j, "Prepare revolver", m.prepareRevolver);
     read(j, "Prepare revolver key", m.prepareRevolverKey);
     read(j, "Hit sound", m.hitSound);
@@ -997,7 +1002,11 @@ static void to_json(json& j, const Config::RageAntiAimConfig& o, const Config::R
 {
     WRITE("Enabled", enabled);
     WRITE("Pitch", pitch);
-    WRITE("Yaw base", yawBase);
+    WRITE_ENUM("Yaw base", yawBase);
+    to_json(j["Manual forward Key"], o.manualForward, KeyBind::NONE);
+    to_json(j["Manual backward Key"], o.manualBackward, KeyBind::NONE);
+    to_json(j["Manual right Key"], o.manualRight, KeyBind::NONE);
+    to_json(j["Manual left Key"], o.manualLeft, KeyBind::NONE);
     WRITE("Yaw add", yawAdd);
     WRITE("Jitter Range", jitterRange);
     WRITE("Spin base", spinBase);
@@ -1219,6 +1228,7 @@ static void to_json(json& j, const Config::Misc& o)
     WRITE("Fast Stop", fastStop);
     WRITE("Bomb timer", bombTimer);
     WRITE("Hurt indicator", hurtIndicator);
+    WRITE("Yaw indicator", yawIndicator);
     WRITE("Prepare revolver", prepareRevolver);
     WRITE("Prepare revolver key", prepareRevolverKey);
     WRITE("Hit sound", hitSound);

--- a/Osiris/Config.h
+++ b/Osiris/Config.h
@@ -10,6 +10,7 @@
 #include "Hacks/SkinChanger.h"
 #include "ConfigStructs.h"
 #include "InputUtil.h"
+#include "Hacks/AntiAim.h"
 
 class Config {
 public:
@@ -66,7 +67,11 @@ public:
     struct RageAntiAimConfig {
         bool enabled = false;
         int pitch = 0; //Off, Down, Zero, Up
-        int yawBase = 0; //Off, Forward, Backward, Right, Left, Spin
+        AntiAim::Yaw yawBase = AntiAim::Yaw::off;
+        KeyBind manualForward{ std::string("manual forward") },
+            manualBackward{ std::string("manual backward") },
+            manualRight{ std::string("manual right") },
+            manualLeft{ std::string("manual left") };
         int yawAdd = 0; //-180/180
         int spinBase = 0; //-180/180
         int jitterRange = 0;
@@ -372,6 +377,7 @@ public:
         std::string killMessageString{ "Gotcha!" };
         ColorToggle3 bombTimer{ 1.0f, 0.55f, 0.0f };
         ColorToggle3 hurtIndicator{ 0.0f, 0.8f, 0.7f };
+        ColorToggle yawIndicator{ 0.47f, 0.32f, 0.66f, 0.8f };
         KeyBind prepareRevolverKey{ std::string("prepare revolver") };
         int hitSound{ 0 };
         int quickHealthshotKey{ 0 };

--- a/Osiris/ConfigStructs.h
+++ b/Osiris/ConfigStructs.h
@@ -204,6 +204,7 @@ using value_t = json::value_t;
 // - object holding default values named 'dummy'
 // - object to write to json named 'o'
 #define WRITE(name, valueName) to_json(j[name], o.valueName, dummy.valueName)
+#define WRITE_ENUM(name, valueName) to_json(j[name], static_cast<int>(o.valueName), static_cast<int>(dummy.valueName))
 
 template <typename T>
 static void to_json(json& j, const T& o, const T& dummy)

--- a/Osiris/GUI.cpp
+++ b/Osiris/GUI.cpp
@@ -661,20 +661,28 @@ void GUI::renderRageAntiAimWindow() noexcept
     ImGui::SetColumnOffset(1, 300.f);
     ImGui::Checkbox("Enabled", &config->rageAntiAim.enabled);
     ImGui::Combo("Pitch", &config->rageAntiAim.pitch, "Off\0Down\0Zero\0Up\0");
-    ImGui::Combo("Yaw base", &config->rageAntiAim.yawBase, "Off\0Forward\0Backward\0Right\0Left\0Spin\0Jitter\0");
+    ImGui::Combo("Yaw base", reinterpret_cast<int*>(&config->rageAntiAim.yawBase), "Off\0Forward\0Backward\0Right\0Left\0Spin\0Jitter\0Manual\0");
     ImGui::PushItemWidth(220.0f);
     ImGui::SliderInt("Yaw add", &config->rageAntiAim.yawAdd, -180, 180, "%d");
     ImGui::PopItemWidth();
-        if ((config->rageAntiAim.yawBase == 6))
+    switch (config->rageAntiAim.yawBase)
     {
-        ImGui::SliderInt("Jitter yaw range", &config->rageAntiAim.jitterRange, 0, 180, "%d");
-    }
-
-    if (config->rageAntiAim.yawBase == 5)
-    {
+    case AntiAim::Yaw::spin:
         ImGui::PushItemWidth(220.0f);
         ImGui::SliderInt("Spin base", &config->rageAntiAim.spinBase, -180, 180, "%d");
         ImGui::PopItemWidth();
+        break;
+    case AntiAim::Yaw::jitter:
+        ImGui::SliderInt("Jitter yaw range", &config->rageAntiAim.jitterRange, 0, 180, "%d");
+        break;
+    case AntiAim::Yaw::manual:
+        ImGui::hotkey("Forward", config->rageAntiAim.manualForward, 60.f);
+        ImGui::hotkey("Backward", config->rageAntiAim.manualBackward, 60.f);
+        ImGui::hotkey("Right", config->rageAntiAim.manualRight, 60.f);
+        ImGui::hotkey("Left", config->rageAntiAim.manualLeft, 60.f);
+        break;
+    default:
+        break;
     }
 
     ImGui::Checkbox("At targets", &config->rageAntiAim.atTargets);
@@ -1776,6 +1784,7 @@ void GUI::renderMiscWindow() noexcept
     ImGui::Checkbox("Fast Stop", &config->misc.fastStop);
     ImGuiCustom::colorPicker("Bomb timer", config->misc.bombTimer);
     ImGuiCustom::colorPicker("Hurt indicator", config->misc.hurtIndicator);
+    ImGuiCustom::colorPicker("Yaw indicator", config->misc.yawIndicator);
     ImGui::Checkbox("Prepare revolver", &config->misc.prepareRevolver);
     ImGui::SameLine();
     ImGui::PushID("Prepare revolver Key");

--- a/Osiris/Hacks/AntiAim.cpp
+++ b/Osiris/Hacks/AntiAim.cpp
@@ -10,6 +10,7 @@
 #include "../Interfaces.h"
 
 static bool flipJitter{ false };
+static float manualYaw{ 0.f };
 
 bool updateLby(bool update = false) noexcept
 {
@@ -99,7 +100,7 @@ void AntiAim::rage(UserCmd* cmd, const Vector& previousViewAngles, const Vector&
     }
     if (cmd->viewangles.y == currentViewAngles.y)
     {
-        if (config->rageAntiAim.yawBase != 0 
+        if (config->rageAntiAim.yawBase != Yaw::off
             && config->rageAntiAim.enabled)   //AntiAim
         {
             float yaw = 0.f;
@@ -128,29 +129,41 @@ void AntiAim::rage(UserCmd* cmd, const Vector& previousViewAngles, const Vector&
                 yaw = yawAngle;
             }
 
-            if (config->rageAntiAim.yawBase != 5)
+            if (config->rageAntiAim.yawBase != Yaw::spin)
                 staticYaw = 0.f;
 
             switch (config->rageAntiAim.yawBase)
             {
-            case 1: //Forward
+            case Yaw::forward:
                 yaw += 0.f;
                 break;
-            case 2: //Back
+            case Yaw::backward:
                 yaw += 180.f;
                 break;
-            case 3: //Right
+            case Yaw::right:
                 yaw += -90.f;
                 break;
-            case 4: //Left
+            case Yaw::left:
                 yaw += 90.f;
                 break;
-            case 5: //Spin
+            case Yaw::spin:
                 staticYaw += static_cast<float>(config->rageAntiAim.spinBase);
                 yaw += staticYaw;
                 break;
-            case 6: //Jitter
+            case Yaw::jitter:
                 yaw += flipJitter ? 180.f + config->rageAntiAim.jitterRange : 180.f - config->rageAntiAim.jitterRange;
+                break;
+            case Yaw::manual:
+                if (config->rageAntiAim.manualForward.isDown())
+                    manualYaw = 0.f;
+                else if (config->rageAntiAim.manualBackward.isDown())
+                    manualYaw = 180.f;
+                else if (config->rageAntiAim.manualRight.isDown())
+                    manualYaw = -90.f;
+                else if (config->rageAntiAim.manualLeft.isDown())
+                    manualYaw = 90.f;
+
+                yaw += manualYaw;
                 break;
             default:
                 break;

--- a/Osiris/Hacks/AntiAim.h
+++ b/Osiris/Hacks/AntiAim.h
@@ -13,4 +13,15 @@ namespace AntiAim
     void run(UserCmd* cmd, const Vector& previousViewAngles, const Vector& currentViewAngles, bool& sendPacket) noexcept;
     void updateInput() noexcept;
     bool canRun(UserCmd* cmd) noexcept;
+
+    enum class Yaw {
+        off,
+        forward,
+        backward,
+        right,
+        left,
+        spin,
+        jitter,
+        manual
+    };
 }

--- a/Osiris/Hacks/Misc.cpp
+++ b/Osiris/Hacks/Misc.cpp
@@ -1174,6 +1174,8 @@ void Misc::hurtIndicator() noexcept
     ImGui::End();
 }
 
+Misc::YawOrientation yawOrientation = Misc::YawOrientation::forward;
+
 void Misc::yawIndicator(ImDrawList* drawList) noexcept
 {
     if (!config->misc.yawIndicator.enabled || !config->rageAntiAim.enabled)

--- a/Osiris/Hacks/Misc.h
+++ b/Osiris/Hacks/Misc.h
@@ -1,18 +1,22 @@
 #pragma once
 
-enum class FrameStage;
-class GameEvent;
-struct ImDrawList;
-struct UserCmd;
-struct Vector;
-struct ViewSetup;
+#include "../SDK/ViewSetup.h";
 
 namespace Misc
 {
+    enum class YawOrientation {
+        none,
+        forward,
+        backward,
+        right,
+        left
+    };
+
     inline bool shouldEdgebug;
     inline float zVelBackup;
     inline float bugSpeed;
     inline int edgebugButtons;
+    inline YawOrientation yawOrientation{ YawOrientation::forward };
 
     bool isInChat() noexcept;
     void edgeBug(UserCmd* cmd, Vector& angView) noexcept;
@@ -42,6 +46,7 @@ namespace Misc
     void fastStop(UserCmd*) noexcept;
     void drawBombTimer() noexcept;
     void hurtIndicator() noexcept;
+    void yawIndicator(ImDrawList* drawList) noexcept;
     void stealNames() noexcept;
     void disablePanoramablur() noexcept;
     bool changeName(bool, const char*, float) noexcept;

--- a/Osiris/Hooks.cpp
+++ b/Osiris/Hooks.cpp
@@ -117,6 +117,7 @@ static HRESULT __stdcall present(IDirect3DDevice9* device, const RECT* src, cons
         Misc::drawOffscreenEnemies(ImGui::GetBackgroundDrawList());
         Misc::drawBombTimer();
         Misc::hurtIndicator();
+        Misc::yawIndicator(ImGui::GetBackgroundDrawList());
         Misc::spectatorList();
         Misc::showKeybinds();
         Visuals::hitMarker(nullptr, ImGui::GetBackgroundDrawList());


### PR DESCRIPTION
This fixes https://github.com/notgoodusename/OsirisAndExtra/issues/133 and adds an indicator in case people want it.

I took the liberty to change a few things such as using an enum for the YawBase. This adds a constraint and improves code readability.

A drawback of my indicator implementation is noted in the code:
> This can get out of sync when switching from another yaw to "manual".
> While it could easily be synced up with AntiAim this would create additional
> overhead and would need some parts to be rewritten for it to look clean.
>
> This out-of-sync state only persists until manual AA got changed at least once.

Was closed without providing any reasoning as of why.