### PR TITLE
Fix shifting with Healthshot in hand

### DIFF
--- a/Osiris/Hacks/Tickbase.cpp
+++ b/Osiris/Hacks/Tickbase.cpp
@@ -147,7 +147,8 @@ bool Tickbase::canShift(int shiftAmount, bool forceShift) noexcept
 
     if (activeWeapon->isKnife() || activeWeapon->isGrenade() || activeWeapon->isBomb()
         || activeWeapon->itemDefinitionIndex2() == WeaponId::Revolver
-        || activeWeapon->itemDefinitionIndex2() == WeaponId::Taser)
+        || activeWeapon->itemDefinitionIndex2() == WeaponId::Taser
+        || activeWeapon->itemDefinitionIndex2() == WeaponId::Healthshot)
         return false;
 
     const float shiftTime = (localPlayer->tickBase() - shiftAmount) * memory->globalVars->intervalPerTick;


### PR DESCRIPTION
While i was playing some deathmatch, i was noticing that if i had any exploit on, the healthshot would sometimes f*ck up and not heal you, so i applied this fixed and now i can finally heal correctly