### PR TITLE
Improved low fps check

### DIFF
--- a/Osiris/Hacks/Ragebot.cpp
+++ b/Osiris/Hacks/Ragebot.cpp
@@ -229,7 +229,7 @@ void Ragebot::run(UserCmd* cmd) noexcept
     frameRate = 0.9f * frameRate + 0.1f * memory->globalVars->absoluteFrameTime;
 
     auto multiPoint = cfg[weaponIndex].multiPoint;
-    if (cfg[weaponIndex].disableMultipointIfLowFPS && static_cast<int>(1 / frameRate) <= 60)
+    if (cfg[weaponIndex].disableMultipointIfLowFPS && static_cast<int>(1 / frameRate) <= 1 / memory->globalVars->intervalPerTick)
         multiPoint = 0;
 
     for (const auto& target : enemies) 
@@ -260,7 +260,7 @@ void Ragebot::run(UserCmd* cmd) noexcept
             }
             else
             {
-                if (cfg[weaponIndex].disableBacktrackIfLowFPS && static_cast<int>(1 / frameRate) <= 60)
+                if (cfg[weaponIndex].disableBacktrackIfLowFPS && static_cast<int>(1 / frameRate) <= 1 / memory->globalVars->intervalPerTick)
                     continue;
 
                 if (!config->backtrack.enabled)


### PR DESCRIPTION
The low FPS check now properly scales with the server's tickrate instead of being at a static 60, as our basic goal with these disablers is to have FPS greater than or equal to the server's tickrate for optimal cheat performance.