### PR TITLE
Optimization / Multipoint changes

### DIFF
--- a/Osiris/Config.cpp
+++ b/Osiris/Config.cpp
@@ -356,6 +356,8 @@ static void from_json(const json& j, Config::Backtrack& b)
 static void from_json(const json& j, Config::Optimizations& o)
 {
     read(j, "Low Performance Mode", o.lowPerformanceMode);
+    read(j, "Low Performance Mode Backtrack", o.lowPerformanceModeBacktrack);
+
 }
 
 static void from_json(const json& j, Config::Chams::Material& m)
@@ -1129,6 +1131,7 @@ static void to_json(json& j, const Config::Backtrack& o, const Config::Backtrack
 static void to_json(json& j, const Config::Optimizations& o, const Config::Optimizations& dummy = {})
 {
     WRITE("Low Performance Mode", lowPerformanceMode);
+    WRITE("Low Performance Mode Backtrack", lowPerformanceModeBacktrack);
 }
 
 static void to_json(json& j, const PurchaseList& o, const PurchaseList& dummy = {})

--- a/Osiris/Config.cpp
+++ b/Osiris/Config.cpp
@@ -272,13 +272,12 @@ static void from_json(const json& j, Config::Ragebot& r)
     read(j, "Auto scope", r.autoScope);
     read(j, "Auto stop", r.autoStop);
     read(j, "Between shots", r.betweenShots);
-    read(j, "Disable multipoint if low fps", r.disableMultipointIfLowFPS);
-    read(j, "Disable backtrack if low fps", r.disableBacktrackIfLowFPS);
     read(j, "Priority", r.priority);
     read(j, "Fov", r.fov);
     read(j, "Hitboxes", r.hitboxes);
     read(j, "Hitchance", r.hitChance);
-    read(j, "Multipoint", r.multiPoint);
+    read(j, "Head Multipoint", r.headMultiPoint);
+    read(j, "Body Multipoint", r.bodyMultiPoint);
     read(j, "Min damage", r.minDamage);
     read(j, "Min damage override", r.minDamageOverride);
 }
@@ -352,6 +351,11 @@ static void from_json(const json& j, Config::Backtrack& b)
     read(j, "Time limit", b.timeLimit);
     read(j, "Fake Latency", b.fakeLatency);
     read(j, "Fake Latency Amount", b.fakeLatencyAmount);
+}
+
+static void from_json(const json& j, Config::Optimizations& o)
+{
+    read(j, "Low Performance Mode", o.lowPerformanceMode);
 }
 
 static void from_json(const json& j, Config::Chams::Material& m)
@@ -983,13 +987,12 @@ static void to_json(json& j, const Config::Ragebot& o, const Config::Ragebot& du
     WRITE("Auto scope", autoScope);
     WRITE("Auto stop", autoStop);
     WRITE("Between shots", betweenShots);
-    WRITE("Disable multipoint if low fps", disableMultipointIfLowFPS);
-    WRITE("Disable backtrack if low fps", disableMultipointIfLowFPS);
     WRITE("Priority", priority);
     WRITE("Fov", fov);
     WRITE("Hitboxes", hitboxes);
     WRITE("Hitchance", hitChance);
-    WRITE("Multipoint", multiPoint);
+    WRITE("Head Multipoint", headMultiPoint);
+    WRITE("Body Multipoint", bodyMultiPoint);
     WRITE("Min damage", minDamage);
     WRITE("Min damage override", minDamageOverride);
 }
@@ -1121,6 +1124,11 @@ static void to_json(json& j, const Config::Backtrack& o, const Config::Backtrack
     WRITE("Time limit", timeLimit);
     WRITE("Fake Latency", fakeLatency);
     WRITE("Fake Latency Amount", fakeLatencyAmount);
+}
+
+static void to_json(json& j, const Config::Optimizations& o, const Config::Optimizations& dummy = {})
+{
+    WRITE("Low Performance Mode", lowPerformanceMode);
 }
 
 static void to_json(json& j, const PurchaseList& o, const PurchaseList& dummy = {})

--- a/Osiris/Config.cpp
+++ b/Osiris/Config.cpp
@@ -357,7 +357,6 @@ static void from_json(const json& j, Config::Optimizations& o)
 {
     read(j, "Low Performance Mode", o.lowPerformanceMode);
     read(j, "Low Performance Mode Backtrack", o.lowPerformanceModeBacktrack);
-
 }
 
 static void from_json(const json& j, Config::Chams::Material& m)

--- a/Osiris/Config.h
+++ b/Osiris/Config.h
@@ -158,6 +158,7 @@ public:
 
     struct Optimizations {
         bool lowPerformanceMode{ false };
+        bool lowPerformanceModeBacktrack{ false };
     } optimizations;
 
     struct Chams {

--- a/Osiris/Config.h
+++ b/Osiris/Config.h
@@ -44,14 +44,13 @@ public:
         bool autoShot{ false };
         bool autoScope{ false };
         bool autoStop{ false };
-        bool disableMultipointIfLowFPS{ false };
-        bool disableBacktrackIfLowFPS{ false };
         bool betweenShots{ false };
         int priority{ 0 };
         float fov{ 0.0f };
         int hitboxes{ 0 };
         int hitChance{ 50 };
-        int multiPoint{ 0 };
+        int headMultiPoint{ 0 };
+        int bodyMultiPoint{ 0 };
         int minDamage{ 1 };
         int minDamageOverride{ 1 };
     };
@@ -156,6 +155,10 @@ public:
         bool fakeLatency = false;
         int fakeLatencyAmount = 200;
     } backtrack;
+
+    struct Optimizations {
+        bool lowPerformanceMode{ false };
+    } optimizations;
 
     struct Chams {
         struct Material : Color4 {

--- a/Osiris/GUI.cpp
+++ b/Osiris/GUI.cpp
@@ -739,6 +739,7 @@ void GUI::renderBacktrackWindow() noexcept
     ImGui::Columns(2, nullptr, false);
     ImGui::SetColumnOffset(1, 300.f);
     ImGui::Checkbox("Enabled", &config->backtrack.enabled);
+    ImGui::Checkbox("Low Performance Mode", &config->optimizations.lowPerformanceModeBacktrack);
     ImGui::Checkbox("Ignore smoke", &config->backtrack.ignoreSmoke);
     ImGui::Checkbox("Ignore flash", &config->backtrack.ignoreFlash);
     ImGui::PushItemWidth(220.0f);

--- a/Osiris/GUI.cpp
+++ b/Osiris/GUI.cpp
@@ -324,8 +324,8 @@ void GUI::renderLegitbotWindow() noexcept
 
 void GUI::renderRagebotWindow() noexcept
 {
-    static const char* hitboxes[]{ "Head","Chest","Stomach","Arms","Legs" };
-    static bool hitbox[ARRAYSIZE(hitboxes)] = { false, false, false, false, false };
+    static const char* hitboxes[]{ "Head","Chest","Stomach","Arms","Legs", "Feet" };
+    static bool hitbox[ARRAYSIZE(hitboxes)] = { false, false, false, false, false, false };
     static std::string previewvalue = "";
     bool once = false;
 
@@ -430,6 +430,7 @@ void GUI::renderRagebotWindow() noexcept
     ImGui::Checkbox("Enabled", &config->ragebot[currentWeapon].enabled);
     ImGui::Columns(2, nullptr, false);
     ImGui::SetColumnOffset(1, 220.0f);
+    ImGui::Checkbox("Low Performance Mode", &config->optimizations.lowPerformanceMode);
     ImGui::Checkbox("Aimlock", &config->ragebot[currentWeapon].aimlock);
     ImGui::Checkbox("Silent", &config->ragebot[currentWeapon].silent);
     ImGui::Checkbox("Friendly fire", &config->ragebot[currentWeapon].friendlyFire);
@@ -442,8 +443,6 @@ void GUI::renderRagebotWindow() noexcept
     ImGui::Checkbox("Auto stop", &config->ragebot[currentWeapon].autoStop);
     ImGui::SameLine();
     ImGui::Checkbox("Between shots", &config->ragebot[currentWeapon].betweenShots);
-    ImGui::Checkbox("Disable multipoint if low fps", &config->ragebot[currentWeapon].disableMultipointIfLowFPS);
-    ImGui::Checkbox("Disable backtrack if low fps", &config->ragebot[currentWeapon].disableBacktrackIfLowFPS);
     ImGui::Combo("Priority", &config->ragebot[currentWeapon].priority, "Health\0Distance\0Fov\0");
 
     for (size_t i = 0; i < ARRAYSIZE(hitbox); i++)
@@ -481,7 +480,8 @@ void GUI::renderRagebotWindow() noexcept
     ImGui::PushItemWidth(240.0f);
     ImGui::SliderFloat("Fov", &config->ragebot[currentWeapon].fov, 0.0f, 255.0f, "%.2f", ImGuiSliderFlags_Logarithmic);
     ImGui::SliderInt("Hitchance", &config->ragebot[currentWeapon].hitChance, 0, 100, "%d");
-    ImGui::SliderInt("Multipoint", &config->ragebot[currentWeapon].multiPoint, 0, 100, "%d");
+    ImGui::SliderInt("Head Multipoint", &config->ragebot[currentWeapon].headMultiPoint, 0, 100, "%d");
+    ImGui::SliderInt("Body Multipoint", &config->ragebot[currentWeapon].bodyMultiPoint, 0, 100, "%d");
     ImGui::SliderInt("Min damage", &config->ragebot[currentWeapon].minDamage, 0, 101, "%d");
     config->ragebot[currentWeapon].minDamage = std::clamp(config->ragebot[currentWeapon].minDamage, 0, 250);
     ImGui::PushID("Min damage override Key");

--- a/Osiris/Hacks/AimbotFunctions.cpp
+++ b/Osiris/Hacks/AimbotFunctions.cpp
@@ -461,7 +461,7 @@ bool AimbotFunction::hitboxIntersection(const matrix3x4 matrix[MAXSTUDIOBONES], 
     return false;
 }
 
-std::vector<Vector> AimbotFunction::multiPoint(Entity* entity, const matrix3x4 matrix[MAXSTUDIOBONES], StudioBbox* hitbox, Vector localEyePos, int _hitbox, int _multiPoint)
+std::vector<Vector> AimbotFunction::multiPoint(Entity* entity, const matrix3x4 matrix[MAXSTUDIOBONES], StudioBbox* hitbox, Vector localEyePos, int _hitbox, int _headMultiPoint, int _bodyMultiPoint)
 {
     auto VectorTransformWrapper = [](const Vector& in1, const matrix3x4 in2, Vector& out)
     {
@@ -485,7 +485,7 @@ std::vector<Vector> AimbotFunction::multiPoint(Entity* entity, const matrix3x4 m
 
     std::vector<Vector> vecArray;
 
-    if (_multiPoint <= 0)
+    if (_headMultiPoint <= 0 && _hitbox == 1 || _bodyMultiPoint <= 0 && _hitbox != 1)
     {
         vecArray.emplace_back(center);
         return vecArray;
@@ -503,24 +503,37 @@ std::vector<Vector> AimbotFunction::multiPoint(Entity* entity, const matrix3x4 m
     Vector top = Vector{ 0, 0, 1 };
     Vector bottom = Vector{ 0, 0, -1 };
 
-    float multiPoint = (min(_multiPoint, 95)) * 0.01f;
-
+    float headMultiPoint = (min(_headMultiPoint, 95)) * 0.01f;
+    float bodyMultiPoint = (min(_bodyMultiPoint, 95)) * 0.01f;
+    static auto frameRate = 1.0f;
+    frameRate = 0.9f * frameRate + 0.1f * memory->globalVars->absoluteFrameTime;
+    // linear scaling 0 - 15 based on how low our fps is compared to the server's tickrate
+    int toOptimize = std::clamp((int)(15 * ((static_cast<int>(1 / frameRate)) <= (1 / memory->globalVars->intervalPerTick)) + 15 * (1 - ((static_cast<int>(1 / frameRate)) - (1 / memory->globalVars->intervalPerTick)) / (1 / memory->globalVars->intervalPerTick)) * ((static_cast<int>(1 / frameRate)) < 2 * (1 / memory->globalVars->intervalPerTick))), 0, 15);
     switch (_hitbox)
     {
     case Hitboxes::Head:
         for (auto i = 0; i < 4; ++i)
             vecArray.emplace_back(center);
 
-        vecArray[1] += top * (hitbox->capsuleRadius * multiPoint);
-        vecArray[2] += right * (hitbox->capsuleRadius * multiPoint);
-        vecArray[3] += left * (hitbox->capsuleRadius * multiPoint);
+        vecArray[1] += top * (hitbox->capsuleRadius * headMultiPoint);
+        vecArray[2] += right * (hitbox->capsuleRadius * headMultiPoint);
+        vecArray[3] += left * (hitbox->capsuleRadius * headMultiPoint);
         break;
-    default://rest
-        for (auto i = 0; i < 3; ++i)
+    case Hitboxes::Neck: // this hitbox is never scanned
+        vecArray.emplace_back(center);
+        break;
+    default:
+        // is optimization disabled || is the hitbox not on the optimization list
+        if (!config->optimizations.lowPerformanceMode || toOptimize < _hitbox + 1) {
+            for (auto i = 0; i < 3; ++i)
+                vecArray.emplace_back(center);
+
+            vecArray[1] += right * (hitbox->capsuleRadius * bodyMultiPoint);
+            vecArray[2] += left * (hitbox->capsuleRadius * bodyMultiPoint);
+        }
+        else
             vecArray.emplace_back(center);
 
-        vecArray[1] += right * (hitbox->capsuleRadius * multiPoint);
-        vecArray[2] += left * (hitbox->capsuleRadius * multiPoint);
         break;
     }
     return vecArray;

--- a/Osiris/Hacks/AimbotFunctions.cpp
+++ b/Osiris/Hacks/AimbotFunctions.cpp
@@ -485,7 +485,7 @@ std::vector<Vector> AimbotFunction::multiPoint(Entity* entity, const matrix3x4 m
 
     std::vector<Vector> vecArray;
 
-    if (_headMultiPoint <= 0 && _hitbox == 1 || _bodyMultiPoint <= 0 && _hitbox != 1)
+    if (_headMultiPoint <= 0 && _hitbox == 0 || _bodyMultiPoint <= 0 && _hitbox != 0)
     {
         vecArray.emplace_back(center);
         return vecArray;

--- a/Osiris/Hacks/AimbotFunctions.h
+++ b/Osiris/Hacks/AimbotFunctions.h
@@ -21,7 +21,7 @@ namespace AimbotFunction
 
     bool hitboxIntersection(const matrix3x4 matrix[MAXSTUDIOBONES], int iHitbox, StudioHitboxSet* set, const Vector& start, const Vector& end) noexcept;
 
-    std::vector<Vector> multiPoint(Entity* entity, const matrix3x4 matrix[MAXSTUDIOBONES], StudioBbox* hitbox, Vector localEyePos, int _hitbox, int _multiPoint);
+    std::vector<Vector> multiPoint(Entity* entity, const matrix3x4 matrix[MAXSTUDIOBONES], StudioBbox* hitbox, Vector localEyePos, int _hitbox, int _headMultiPoint, int _bodyMultiPoint);
 
     bool hitChance(Entity* localPlayer, Entity* entity, StudioHitboxSet*, const matrix3x4 matrix[MAXSTUDIOBONES], Entity* activeWeapon, const Vector& destination, const UserCmd* cmd, const int hitChance) noexcept;
 }

--- a/Osiris/Hacks/Animations.cpp
+++ b/Osiris/Hacks/Animations.cpp
@@ -276,7 +276,7 @@ float getMaximumTicks() noexcept
 
 float getTimeLimit() noexcept
 {
-    if (!config->optimizations.lowPerformanceMode)
+    if (!config->optimizations.lowPerformanceModeBacktrack)
         return getMaximumTicks();
 
     static auto frameRate = 1.0f;

--- a/Osiris/Hacks/Animations.cpp
+++ b/Osiris/Hacks/Animations.cpp
@@ -274,7 +274,7 @@ float getMaximumTicks() noexcept
     static auto frameRate = 1.0f;
     frameRate = 0.9f * frameRate + 0.1f * memory->globalVars->absoluteFrameTime;
 
-    if (static_cast<int>(1 / frameRate) <= 1 / memory->globalVars->intervalPerTick)
+    if (static_cast<int>(1 / frameRate) <= 1 / memory->globalVars->intervalPerTick && config->optimizations.lowPerformanceModeBacktrack)
         return 0.f;
 
     return static_cast<float>(config->backtrack.timeLimit) / 1000.f + getExtraTicks();

--- a/Osiris/Hacks/Legitbot.cpp
+++ b/Osiris/Hacks/Legitbot.cpp
@@ -142,7 +142,7 @@ void Legitbot::run(UserCmd* cmd) noexcept
                 if (!hitbox)
                     continue;
 
-                for (auto& bonePosition : AimbotFunction::multiPoint(entity, player.matrix.data(), hitbox, localPlayerEyePosition, j, 0))
+                for (auto& bonePosition : AimbotFunction::multiPoint(entity, player.matrix.data(), hitbox, localPlayerEyePosition, j, 0, 0))
                 {
                     const auto angle{ AimbotFunction::calculateRelativeAngle(localPlayerEyePosition, bonePosition, cmd->viewangles + aimPunch) };
                     const auto fov{ angle.length2D() };

--- a/Osiris/Hacks/Ragebot.cpp
+++ b/Osiris/Hacks/Ragebot.cpp
@@ -177,8 +177,8 @@ void Ragebot::run(UserCmd* cmd) noexcept
     hitbox[Hitboxes::Belly] = (cfg[weaponIndex].hitboxes & 1 << 2) == 1 << 2;
     hitbox[Hitboxes::Pelvis] = (cfg[weaponIndex].hitboxes & 1 << 2) == 1 << 2;
 
-    // Limbs will only be scanned when we can afford it
-    if (static_cast<int>(1 / frameRate) > 1 / memory->globalVars->intervalPerTick || !config->optimizations.lowPerformanceMode) {
+    // Limbs will only be scanned when we can afford it, unless they are the only selected hitboxes
+   if (static_cast<int>(1 / frameRate) > 1 / memory->globalVars->intervalPerTick && !((cfg[weaponIndex].hitboxes & 1 << 2) == (cfg[weaponIndex].hitboxes & 1 << 0) == (cfg[weaponIndex].hitboxes & 1 << 1) == 0) || !config->optimizations.lowPerformanceMode) {
         // Arms
         hitbox[Hitboxes::RightUpperArm] = (cfg[weaponIndex].hitboxes & 1 << 3) == 1 << 3;
         hitbox[Hitboxes::RightForearm] = (cfg[weaponIndex].hitboxes & 1 << 3) == 1 << 3;

--- a/Osiris/Hacks/Ragebot.cpp
+++ b/Osiris/Hacks/Ragebot.cpp
@@ -266,7 +266,7 @@ void Ragebot::run(UserCmd* cmd) noexcept
             }
             else
             {
-                if (!config->backtrack.enabled)
+                if (!config->backtrack.enabled || static_cast<int>(1 / frameRate) <= 1 / memory->globalVars->intervalPerTick && config->optimizations.lowPerformanceModeBacktrack)
                     continue;
 
                 const auto records = Animations::getBacktrackRecords(entity->index());


### PR DESCRIPTION
**-** Replaced current optimizations (multipoint / backtrack) with new "Low Performance Mode" (much more dynamic and less impactful to ragebot performance):

- Low performance mode will adjust the amount of backtrack ticks processed based on your fps (maximum value achieved when fps is greater than or equal to 2 * (the server's tickrate), minimum value of 0 achieved when fps is less than or equal to the server's tickrate).
- Low performance mode will also adjust the amount of hitboxes (exluding the head hitbox) that are processed by the multipoint function (maximum value of 15 achieved when fps is greater than or equal to 2 * (the server's tickrate), minimum value of 0 achieved when fps is less than or equal to the server's tickrate). 
- In critical cases, low performance mode will prevent limb scanning.

**-** Added feet as a selectable ragebot hitbox group.
**-** Added hands to the arms hitbox group.
**-** Scaled multipoint into two options: head multipoint and body multipoint.
