### PR TITLE
Exploit / Antiaim / Animfix improvements

### DIFF
--- a/Osiris/Hacks/AntiAim.cpp
+++ b/Osiris/Hacks/AntiAim.cpp
@@ -108,7 +108,7 @@ void AntiAim::rage(UserCmd* cmd, const Vector& previousViewAngles, const Vector&
             float yaw = 0.f;
             static float staticYaw = 0.f;
             static bool flipJitter = false;
-            if (sendPacket)
+            if (sendPacket && !AntiAim::getDidShoot())
                 flipJitter ^= 1;
             if (config->rageAntiAim.atTargets)
             {

--- a/Osiris/Hacks/AntiAim.cpp
+++ b/Osiris/Hacks/AntiAim.cpp
@@ -2,12 +2,17 @@
 
 #include "AimbotFunctions.h"
 #include "AntiAim.h"
+#include "Tickbase.h"
 
 #include "../SDK/Engine.h"
 #include "../SDK/Entity.h"
 #include "../SDK/EntityList.h"
 #include "../SDK/NetworkChannel.h"
 #include "../SDK/UserCmd.h"
+
+static bool isShooting{ false };
+static bool didShoot{ false };
+static float lastShotTime{ 0.f };
 
 bool updateLby(bool update = false) noexcept
 {
@@ -76,7 +81,7 @@ bool autoDirection(Vector eyeAngle) noexcept
 
 void AntiAim::rage(UserCmd* cmd, const Vector& previousViewAngles, const Vector& currentViewAngles, bool& sendPacket) noexcept
 {
-    if (cmd->viewangles.x == currentViewAngles.x && config->rageAntiAim.enabled)
+    if ((cmd->viewangles.x == currentViewAngles.x || Tickbase::isShifting()) && config->rageAntiAim.enabled)
     {
         switch (config->rageAntiAim.pitch)
         {
@@ -95,7 +100,7 @@ void AntiAim::rage(UserCmd* cmd, const Vector& previousViewAngles, const Vector&
             break;
         }
     }
-    if (cmd->viewangles.y == currentViewAngles.y)
+    if (cmd->viewangles.y == currentViewAngles.y || Tickbase::isShifting())
     {
         if (config->rageAntiAim.yawBase != Yaw::off
             && config->rageAntiAim.enabled)   //AntiAim
@@ -197,7 +202,7 @@ void AntiAim::rage(UserCmd* cmd, const Vector& previousViewAngles, const Vector&
                 yaw += static_cast<float>(config->rageAntiAim.yawAdd);
             cmd->viewangles.y += yaw;
         }
-        if (config->fakeAngle.enabled) //Fakeangle
+        if (config->fakeAngle.enabled && !Tickbase::isShifting()) //Fakeangle
         {
             if (const auto gameRules = (*memory->gameRules); gameRules)
                 if (getGameMode() != GameMode::Competitive && gameRules->isValveDS())
@@ -277,7 +282,7 @@ void AntiAim::rage(UserCmd* cmd, const Vector& previousViewAngles, const Vector&
 
 void AntiAim::legit(UserCmd* cmd, const Vector& previousViewAngles, const Vector& currentViewAngles, bool& sendPacket) noexcept
 {
-    if (cmd->viewangles.y == currentViewAngles.y) 
+    if (cmd->viewangles.y == currentViewAngles.y && !Tickbase::isShifting()) 
     {
         bool invert = config->legitAntiAim.invert.isActive();
         float desyncAngle = localPlayer->getMaxDesyncAngle() * 2.f;
@@ -383,4 +388,34 @@ bool AntiAim::canRun(UserCmd* cmd) noexcept
         return true;
 
     return true;
+}
+
+float AntiAim::getLastShotTime()
+{
+    return lastShotTime;
+}
+
+bool AntiAim::getIsShooting()
+{
+    return isShooting;
+}
+
+bool AntiAim::getDidShoot()
+{
+    return didShoot;
+}
+
+void AntiAim::setLastShotTime(float shotTime)
+{
+    lastShotTime = shotTime;
+}
+
+void AntiAim::setIsShooting(bool shooting)
+{
+    isShooting = shooting;
+}
+
+void AntiAim::setDidShoot(bool shot)
+{
+    didShoot = shot;
 }

--- a/Osiris/Hacks/AntiAim.h
+++ b/Osiris/Hacks/AntiAim.h
@@ -13,4 +13,11 @@ namespace AntiAim
     void run(UserCmd* cmd, const Vector& previousViewAngles, const Vector& currentViewAngles, bool& sendPacket) noexcept;
     void updateInput() noexcept;
     bool canRun(UserCmd* cmd) noexcept;
+
+    float getLastShotTime();
+    bool getIsShooting();
+    bool getDidShoot();
+    void setLastShotTime(float shotTime);
+    void setIsShooting(bool shooting);
+    void setDidShoot(bool shot);
 }

--- a/Osiris/Hacks/Fakelag.cpp
+++ b/Osiris/Hacks/Fakelag.cpp
@@ -1,3 +1,4 @@
+#include "AntiAim.h"
 #include "EnginePrediction.h"
 #include "Fakelag.h"
 #include "Tickbase.h"
@@ -16,6 +17,11 @@ void Fakelag::run(bool& sendPacket) noexcept
     const auto netChannel = interfaces->engine->getNetworkChannel();
     if (!netChannel)
         return;
+
+    if (AntiAim::getDidShoot()) {
+        sendPacket = true;
+        return;
+    }   
 
     auto chokedPackets = config->legitAntiAim.enabled || config->fakeAngle.enabled ? 2 : 0;
     if (config->fakelag.enabled)

--- a/Osiris/Hacks/Tickbase.cpp
+++ b/Osiris/Hacks/Tickbase.cpp
@@ -3,6 +3,7 @@
 #include "../Memory.h"
 
 #include "Tickbase.h"
+#include "AntiAim.h"
 
 #include "../SDK/ClientState.h"
 #include "../SDK/Entity.h"
@@ -120,7 +121,7 @@ bool Tickbase::canRun() noexcept
         return true;
     }
 
-    if ((ticksAllowedForProcessing < targetTickShift || chokedPackets > maxUserCmdProcessTicks - targetTickShift) && memory->globalVars->realtime - realTime > 1.0f)
+    if ((ticksAllowedForProcessing < targetTickShift || chokedPackets > maxUserCmdProcessTicks - targetTickShift) && memory->globalVars->realtime - realTime > 1.0f && (memory->globalVars->realtime - AntiAim::getLastShotTime() > 1.0f || hasHadTickbaseActive == false))
     {
         ticksAllowedForProcessing = min(ticksAllowedForProcessing++, maxUserCmdProcessTicks);
         chokedPackets = max(chokedPackets--, 0);

--- a/Osiris/Hooks.cpp
+++ b/Osiris/Hooks.cpp
@@ -310,6 +310,17 @@ static bool __stdcall createMove(float inputSampleTime, UserCmd* cmd, bool& send
         Misc::autoStrafe(cmd, currentViewAngles);
         Misc::jumpBug(cmd);
 
+        if (AntiAim::canRun(cmd))
+        {
+            AntiAim::setIsShooting(false);
+            AntiAim::run(cmd, previousViewAngles, currentViewAngles, sendPacket);
+        }
+        else
+        {
+            AntiAim::setLastShotTime(memory->globalVars->realtime);
+            AntiAim::setIsShooting(true);
+        }
+
         //Clamp angles and fix movement
         auto viewAnglesDelta{ cmd->viewangles - previousViewAngles };
         viewAnglesDelta.normalize();
@@ -340,6 +351,7 @@ static bool __stdcall createMove(float inputSampleTime, UserCmd* cmd, bool& send
         Misc::jumpStats(cmd);
         Animations::update(cmd, sendPacket);
         Animations::fake();
+        AntiAim::setDidShoot(AntiAim::getIsShooting());
         return false;
     }
 
@@ -387,8 +399,14 @@ static bool __stdcall createMove(float inputSampleTime, UserCmd* cmd, bool& send
 
     if (AntiAim::canRun(cmd))
     {
+        AntiAim::setIsShooting(false);
         Fakelag::run(sendPacket);
         AntiAim::run(cmd, previousViewAngles, currentViewAngles, sendPacket);
+    }
+    else
+    {
+        AntiAim::setLastShotTime(memory->globalVars->realtime);
+        AntiAim::setIsShooting(true);
     }
 
     Misc::fakeDuck(cmd, sendPacket);
@@ -431,6 +449,7 @@ static bool __stdcall createMove(float inputSampleTime, UserCmd* cmd, bool& send
     Misc::jumpStats(cmd);
     Animations::update(cmd, sendPacket);
     Animations::fake();
+    AntiAim::setDidShoot(AntiAim::getIsShooting());
     return false;
 }
 


### PR DESCRIPTION
- Fixed antiaim temporarily turning off when switching off tickbase exploits.
- Fixed tickbase exploits attempting to recharge while the user is still shooting.
- Fixed thirdperson not  animating choked shot angles (if you shoot while choking, your shot angles will still be animated at the end of your choke cycle due to sv_maxusrcmdprocessticks_holdaim).
- Improved the way fakelag behaves when shooting: 
    - Previously, shooting while fakelagging would expose your onshot angles for the same amount of time as the length of your choke cycle. With this change, your onshot angles will always be exposed for just 1 tick, regardless of your fakelag.