### PR TITLE
Add Magnet Triggerbot & Aim position line

### DIFF
--- a/Osiris/Config.cpp
+++ b/Osiris/Config.cpp
@@ -702,7 +702,8 @@ static void from_json(const json& j, Config::Misc& m)
     read<value_t::object>(j, "Auto peek", m.autoPeek);
     read(j, "Auto peek key", m.autoPeekKey);
     read<value_t::object>(j, "Noscope crosshair", m.noscopeCrosshair);
-    read<value_t::object>(j, "Recoil crosshair", m.recoilCrosshair);
+    read<value_t::object>(j, "Recoil crosshair", m.recoilCrosshair); 
+    read<value_t::object>(j, "Headshot line", m.headshotLine);
     read(j, "Auto pistol", m.autoPistol);
     read(j, "Auto reload", m.autoReload);
     read(j, "Auto accept", m.autoAccept);
@@ -1366,6 +1367,7 @@ static void to_json(json& j, const Config::Misc& o)
     WRITE("Auto peek key", autoPeekKey);
     WRITE("Noscope crosshair", noscopeCrosshair);
     WRITE("Recoil crosshair", recoilCrosshair);
+    WRITE("Headshot line", headshotLine);
     WRITE("Auto pistol", autoPistol);
     WRITE("Auto reload", autoReload);
     WRITE("Auto accept", autoAccept);

--- a/Osiris/Config.cpp
+++ b/Osiris/Config.cpp
@@ -286,6 +286,7 @@ static void from_json(const json& j, Config::Ragebot& r)
 static void from_json(const json& j, Config::Triggerbot& t)
 {
     read(j, "Enabled", t.enabled);
+    read(j, "Magnet", t.magnet);
     read(j, "Friendly fire", t.friendlyFire);
     read(j, "Scoped only", t.scopedOnly);
     read(j, "Ignore flash", t.ignoreFlash);
@@ -1020,6 +1021,7 @@ static void to_json(json& j, const Config::Ragebot& o, const Config::Ragebot& du
 static void to_json(json& j, const Config::Triggerbot& o, const Config::Triggerbot& dummy = {})
 {
     WRITE("Enabled", enabled);
+    WRITE("Magnet", magnet);
     WRITE("Friendly fire", friendlyFire);
     WRITE("Scoped only", scopedOnly);
     WRITE("Ignore flash", ignoreFlash);

--- a/Osiris/Config.h
+++ b/Osiris/Config.h
@@ -394,7 +394,8 @@ public:
         char clanTag[16];
         char name[16];
         ColorToggleThickness noscopeCrosshair;
-        ColorToggleThickness recoilCrosshair;
+        ColorToggleThickness recoilCrosshair; 
+        ColorToggleThickness headshotLine;
         ColorToggleThickness nadeDamagePredict;
         Color4 nadeTrailPredict;
         Color4 nadeCirclePredict{ 0.f, 0.5f, 1.f, 1.f };

--- a/Osiris/Config.h
+++ b/Osiris/Config.h
@@ -135,6 +135,7 @@ public:
 
     struct Triggerbot {
         bool enabled = false;
+        bool magnet = false;
         bool friendlyFire = false;
         bool scopedOnly = true;
         bool ignoreFlash = false;

--- a/Osiris/GUI.cpp
+++ b/Osiris/GUI.cpp
@@ -607,6 +607,7 @@ void GUI::renderTriggerbotWindow() noexcept
     ImGui::PopID();
     ImGui::SameLine();
     ImGui::Checkbox("Enabled", &config->triggerbot[currentWeapon].enabled);
+    ImGui::Checkbox("Magnet", &config->triggerbot[currentWeapon].magnet);
     ImGui::Checkbox("Friendly fire", &config->triggerbot[currentWeapon].friendlyFire);
     ImGui::Checkbox("Scoped only", &config->triggerbot[currentWeapon].scopedOnly);
     ImGui::Checkbox("Ignore flash", &config->triggerbot[currentWeapon].ignoreFlash);

--- a/Osiris/GUI.cpp
+++ b/Osiris/GUI.cpp
@@ -1808,6 +1808,7 @@ void GUI::renderMiscWindow() noexcept
     ImGui::PopID();
     ImGuiCustom::colorPicker("Noscope crosshair", config->misc.noscopeCrosshair);
     ImGuiCustom::colorPicker("Recoil crosshair", config->misc.recoilCrosshair);
+    ImGuiCustom::colorPicker("Aim position line", config->misc.headshotLine);
     ImGui::Checkbox("Auto pistol", &config->misc.autoPistol);
     ImGui::Checkbox("Auto reload", &config->misc.autoReload);
     ImGui::Checkbox("Auto accept", &config->misc.autoAccept);

--- a/Osiris/Hacks/Legitbot.cpp
+++ b/Osiris/Hacks/Legitbot.cpp
@@ -13,7 +13,7 @@ void Legitbot::updateInput() noexcept
 
 void Legitbot::run(UserCmd* cmd) noexcept
 {
-    if (!config->legitbotKey.isActive())
+    if (!config->legitbotKey.isActive() && !config->triggerbotKey.isActive())
         return;
 
     if (!localPlayer || localPlayer->nextAttack() > memory->globalVars->serverTime() || localPlayer->isDefusing() || localPlayer->waitForNoAttack())
@@ -39,6 +39,14 @@ void Legitbot::run(UserCmd* cmd) noexcept
     if (!cfg[weaponIndex].enabled)
         weaponIndex = 0;
 
+    auto magnetWeaponIndex = getWeaponIndex(activeWeapon->itemDefinitionIndex2());
+
+    if (!config->triggerbot[magnetWeaponIndex].enabled)
+        magnetWeaponIndex = weaponClass;
+
+    if (!config->triggerbot[magnetWeaponIndex].enabled)
+        magnetWeaponIndex = 0;
+
     const auto aimPunch = activeWeapon->requiresRecoilControl() ? localPlayer->getAimPunch() : Vector{ };
 
     if (config->recoilControlSystem.enabled && (config->recoilControlSystem.horizontal || config->recoilControlSystem.vertical) && aimPunch.notNull())
@@ -46,7 +54,7 @@ void Legitbot::run(UserCmd* cmd) noexcept
         static Vector lastAimPunch{ };
         if (localPlayer->shotsFired() > config->recoilControlSystem.shotsFired)
         {
-            if (cmd->buttons & UserCmd::IN_ATTACK)
+            if (cmd->buttons & UserCmd::IN_ATTACK || (config->triggerbotKey.isActive() && config->triggerbot[magnetWeaponIndex].magnet))
             {
                 Vector currentPunch = aimPunch;
 
@@ -83,7 +91,7 @@ void Legitbot::run(UserCmd* cmd) noexcept
     if (!cfg[weaponIndex].ignoreFlash && localPlayer->isFlashed())
         return;
 
-    if (cfg[weaponIndex].enabled && (cmd->buttons & UserCmd::IN_ATTACK || cfg[weaponIndex].aimlock)) {
+    if (cfg[weaponIndex].enabled && ((cmd->buttons & UserCmd::IN_ATTACK || (config->triggerbotKey.isActive() && config->triggerbot[magnetWeaponIndex].magnet)) || cfg[weaponIndex].aimlock)) {
 
         auto bestFov = cfg[weaponIndex].fov;
         Vector bestTarget{ };

--- a/Osiris/Hacks/Misc.h
+++ b/Osiris/Hacks/Misc.h
@@ -44,6 +44,7 @@ namespace Misc
     void spectatorList() noexcept;
     void noscopeCrosshair(ImDrawList* drawlist) noexcept;
     void recoilCrosshair(ImDrawList* drawList) noexcept;
+    void headshotLine(ImDrawList* drawList) noexcept;
     void watermark() noexcept;
     void prepareRevolver(UserCmd*) noexcept;
     void fastPlant(UserCmd*) noexcept;

--- a/Osiris/Hooks.cpp
+++ b/Osiris/Hooks.cpp
@@ -116,6 +116,7 @@ static HRESULT __stdcall present(IDirect3DDevice9* device, const RECT* src, cons
         Visuals::drawAimbotFov(ImGui::GetBackgroundDrawList());
         Misc::noscopeCrosshair(ImGui::GetBackgroundDrawList());
         Misc::recoilCrosshair(ImGui::GetBackgroundDrawList());
+        Misc::headshotLine(ImGui::GetBackgroundDrawList());
         Misc::drawOffscreenEnemies(ImGui::GetBackgroundDrawList());
         Misc::drawBombTimer();
         Misc::hurtIndicator();


### PR DESCRIPTION
The significance of adding a magnet triggerbot switch is to be able to use the legitbot without "aimlock" enabled, and at the same time cloud achieve a function similar to autoshot in a more "legit" way than ragebot